### PR TITLE
fix: remove puppeteer response on undelegation error

### DIFF
--- a/contracts/core/src/contract.rs
+++ b/contracts/core/src/contract.rs
@@ -856,6 +856,7 @@ fn execute_tick_unbonding(
         }
         drop_puppeteer_base::msg::ResponseHookMsg::Error(response) => match response.transaction {
             drop_puppeteer_base::msg::Transaction::Undelegate { batch_id, .. } => {
+                LAST_PUPPETEER_RESPONSE.remove(deps.storage);
                 attrs.push(attr("batch_id", batch_id.to_string()));
                 let mut unbond = unbond_batches_map().load(deps.storage, batch_id)?;
                 unbond.status = UnbondBatchStatus::UnbondFailed;


### PR DESCRIPTION
Report N48. LAST_PUPPETEER_RESPONSE is not being reset on Undelegate error
