### PR TITLE
Fix FSM state staking rewards

### DIFF
--- a/contracts/core/src/contract.rs
+++ b/contracts/core/src/contract.rs
@@ -841,10 +841,7 @@ fn execute_tick_staking_rewards(
     info: MessageInfo,
     config: &Config,
 ) -> ContractResult<Response<NeutronMsg>> {
-    let response_msg = get_received_puppeteer_response(deps.as_ref())?;
-    if let drop_puppeteer_base::msg::ResponseHookMsg::Error(..) = response_msg {
-        return Err(ContractError::PreviousStakingWasFailed {});
-    }
+    let _response_msg = get_received_puppeteer_response(deps.as_ref())?;
     LAST_PUPPETEER_RESPONSE.remove(deps.storage);
     let mut attrs = vec![attr("action", "tick_staking")];
     let mut messages = vec![];


### PR DESCRIPTION
In contracts/core/src/contract.rs:838-861, the execute_tick_staking_rewards function within the core contract acts as the designated handler when the ContractState transitions to StakingRewards during routine procedures.
However, if during this process the puppeteer contract callback to the PuppeteerHook stores a ResponseHookMsg::Error because of a timeout or an error in the ICA transaction, the execute_tick_staking_rewards function consistently returns a PreviousStakingWasFailed error in line 846.
Consequently, lacking an alternative handler to progress the ContractState, the routine procedure becomes unable to proceed, resulting in the protocol becoming permanently stuck.
