### PR TITLE
Knots improvements

### DIFF
--- a/contracts/core/src/contract.rs
+++ b/contracts/core/src/contract.rs
@@ -523,7 +523,6 @@ fn execute_tick_idle(
 ) -> ContractResult<Response<NeutronMsg>> {
     let mut attrs = vec![
         attr("action", "tick_idle"),
-        attr("knot", "001"),
         attr("knot", "000"),
     ];
     let last_idle_call = LAST_IDLE_CALL.load(deps.storage)?;
@@ -566,6 +565,8 @@ fn execute_tick_idle(
             }
         }
     } else {
+        LAST_IDLE_CALL.save(deps.storage, &env.block.time.seconds())?;
+        attrs.push(attr("knot", "004"));
         let unbonding_batches = unbond_batches_map()
             .idx
             .status
@@ -608,7 +609,6 @@ fn execute_tick_idle(
         attrs.push(attr("knot", "007"));
         let transfer: Option<TransferReadyBatchesMsg> = match unbonded_batches.len() {
             0 => {
-                attrs.push(attr("knot", "045"));
                 None
             } // we have nothing to do
             1 => {
@@ -772,8 +772,6 @@ fn execute_tick_idle(
             attrs.push(attr("knot", "012"));
             attrs.push(attr("state", "claiming"));
         }
-        LAST_IDLE_CALL.save(deps.storage, &env.block.time.seconds())?;
-        attrs.push(attr("knot", "004"));
     }
     Ok(response("execute-tick_idle", CONTRACT_NAME, attrs).add_messages(messages))
 }
@@ -784,7 +782,7 @@ fn execute_tick_peripheral(
     _info: MessageInfo,
     _config: &Config,
 ) -> ContractResult<Response<NeutronMsg>> {
-    let mut attrs = vec![attr("action", "tick_peripheral"), attr("knot", "001")];
+    let mut attrs = vec![attr("action", "tick_peripheral")];
     let res = get_received_puppeteer_response(deps.as_ref())?;
 
     if let drop_puppeteer_base::msg::ResponseHookMsg::Success(msg) = res {
@@ -815,7 +813,7 @@ fn execute_tick_claiming(
     info: MessageInfo,
     config: &Config,
 ) -> ContractResult<Response<NeutronMsg>> {
-    let mut attrs = vec![attr("action", "tick_claiming"), attr("knot", "001")];
+    let mut attrs = vec![attr("action", "tick_claiming")];
     let response_msg = get_received_puppeteer_response(deps.as_ref())?;
     LAST_PUPPETEER_RESPONSE.remove(deps.storage);
     let mut messages = vec![];
@@ -891,7 +889,7 @@ fn execute_tick_staking_bond(
     info: MessageInfo,
     config: &Config,
 ) -> ContractResult<Response<NeutronMsg>> {
-    let mut attrs = vec![attr("action", "tick_staking_bond"), attr("knot", "001")];
+    let mut attrs = vec![attr("action", "tick_staking_bond")];
     let response_msg = get_received_staker_response(deps.as_ref())?;
     if let drop_staking_base::msg::staker::ResponseHookMsg::Success(response) = response_msg {
         let (_, puppeteer_height, _): drop_staking_base::msg::puppeteer::BalancesResponse =
@@ -942,7 +940,6 @@ fn execute_tick_staking_rewards(
 ) -> ContractResult<Response<NeutronMsg>> {
     let mut attrs = vec![
         attr("action", "tick_staking"),
-        attr("knot", "001"),
         attr("knot", "022"),
     ];
     let _response_msg = get_received_puppeteer_response(deps.as_ref())?;
@@ -972,7 +969,6 @@ fn execute_tick_unbonding(
 ) -> ContractResult<Response<NeutronMsg>> {
     let mut attrs = vec![
         attr("action", "tick_unbonding"),
-        attr("knot", "001"),
         attr("knot", "029"),
     ];
     let res = get_received_puppeteer_response(deps.as_ref())?;

--- a/contracts/core/src/tests.rs
+++ b/contracts/core/src/tests.rs
@@ -811,7 +811,6 @@ fn test_execute_tick_idle_non_native_rewards() {
                 Event::new("crates.io:drop-staking__drop-core-execute-tick_idle").add_attributes(
                     vec![
                         ("action", "tick_idle"),
-                        ("knot", "001"),
                         ("knot", "000"),
                         ("knot", "002"),
                         ("knot", "003"),
@@ -939,7 +938,6 @@ fn test_execute_tick_idle_get_pending_lsm_shares_transfer() {
                 Event::new("crates.io:drop-staking__drop-core-execute-tick_idle").add_attributes(
                     vec![
                         ("action", "tick_idle"),
-                        ("knot", "001"),
                         ("knot", "000"),
                         ("knot", "002"),
                         ("knot", "003"),
@@ -1084,7 +1082,6 @@ fn test_idle_tick_pending_lsm_redeem() {
                 Event::new("crates.io:drop-staking__drop-core-execute-tick_idle").add_attributes(
                     vec![
                         ("action", "tick_idle"),
-                        ("knot", "001"),
                         ("knot", "000"),
                         ("knot", "002"),
                         ("knot", "003"),
@@ -1380,20 +1377,18 @@ fn test_tick_idle_claim_wo_unbond() {
                 Event::new("crates.io:drop-staking__drop-core-execute-tick_idle").add_attributes(
                     vec![
                         ("action", "tick_idle"),
-                        ("knot", "001"),
                         ("knot", "000"),
                         ("knot", "002"),
                         ("knot", "003"),
+                        ("knot", "004"),
                         ("knot", "005"),
                         ("knot", "007"),
-                        ("knot", "045"),
                         ("knot", "009"),
                         ("knot", "010"),
                         ("validators_to_claim", "valoper_address"),
                         ("knot", "011"),
                         ("knot", "012"),
                         ("state", "claiming"),
-                        ("knot", "004"),
                     ]
                 )
             )
@@ -1544,10 +1539,10 @@ fn test_tick_idle_claim_with_unbond_transfer() {
         Response::new()
         .add_event(Event::new("crates.io:drop-staking__drop-core-execute-tick_idle").add_attributes(vec![
             ("action", "tick_idle" ),
-            ("knot", "001"),
             ("knot", "000"),
             ("knot", "002"),
             ("knot", "003"),
+            ("knot", "004"),
             ("knot", "005"),
             ("knot", "007"),
             ("knot", "008"),
@@ -1557,7 +1552,6 @@ fn test_tick_idle_claim_with_unbond_transfer() {
             ("knot", "011"),
             ("knot", "012"),
             ("state",  "claiming"),
-            ("knot", "004"),
         ]))
         .add_submessage(SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: "puppeteer_contract".to_string(), 
@@ -1694,13 +1688,12 @@ fn test_tick_idle_staking_bond() {
                 Event::new("crates.io:drop-staking__drop-core-execute-tick_idle").add_attributes(
                     vec![
                         ("action", "tick_idle"),
-                        ("knot", "001"),
                         ("knot", "000"),
                         ("knot", "002"),
                         ("knot", "003"),
+                        ("knot", "004"),
                         ("knot", "005"),
                         ("knot", "007"),
-                        ("knot", "045"),
                         ("knot", "009"),
                         ("knot", "010"),
                         ("validators_to_claim", "empty"),
@@ -1708,7 +1701,6 @@ fn test_tick_idle_staking_bond() {
                         ("knot", "016"),
                         ("knot", "017"),
                         ("state", "staking_bond"),
-                        ("knot", "004"),
                     ]
                 )
             )
@@ -1860,13 +1852,12 @@ fn test_tick_idle_staking() {
                 Event::new("crates.io:drop-staking__drop-core-execute-tick_idle").add_attributes(
                     vec![
                         ("action", "tick_idle"),
-                        ("knot", "001"),
                         ("knot", "000"),
                         ("knot", "002"),
                         ("knot", "003"),
+                        ("knot", "004"),
                         ("knot", "005"),
                         ("knot", "007"),
-                        ("knot", "045"),
                         ("knot", "009"),
                         ("knot", "010"),
                         ("validators_to_claim", "empty"),
@@ -1875,7 +1866,6 @@ fn test_tick_idle_staking() {
                         ("knot", "021"),
                         ("knot", "022"),
                         ("state", "staking_rewards"),
-                        ("knot", "004"),
                     ]
                 )
             )
@@ -2057,23 +2047,25 @@ fn test_tick_idle_unbonding() {
                 Event::new("crates.io:drop-staking__drop-core-execute-tick_idle").add_attributes(
                     vec![
                         ("action", "tick_idle"),
-                        ("knot", "001"),
                         ("knot", "000"),
                         ("knot", "002"),
                         ("knot", "003"),
+                        ("knot", "004"),
                         ("knot", "005"),
                         ("knot", "007"),
-                        ("knot", "045"),
                         ("knot", "009"),
                         ("knot", "010"),
                         ("validators_to_claim", "empty"),
                         ("knot", "015"),
                         ("knot", "020"),
                         ("knot", "024"),
+                        ("knot", "026"),
+                        ("knot", "027"),
+                        ("knot", "045"),
+                        ("knot", "046"),
                         ("knot", "028"),
                         ("knot", "029"),
                         ("state", "unbonding"),
-                        ("knot", "004"),
                     ]
                 )
             )
@@ -2243,7 +2235,9 @@ fn test_tick_claiming_wo_transfer_stake() {
                 Event::new("crates.io:drop-staking__drop-core-execute-tick_claiming")
                     .add_attributes(vec![
                         ("action", "tick_claiming"),
-                        ("knot", "001"),
+                        ("knot", "012"),
+                        ("knot", "047"),
+                        ("knot", "013"),
                         ("knot", "015"),
                         ("knot", "020"),
                         ("knot", "021"),
@@ -2415,10 +2409,16 @@ fn test_tick_claiming_wo_transfer_unbonding() {
                 Event::new("crates.io:drop-staking__drop-core-execute-tick_claiming")
                     .add_attributes(vec![
                         ("action", "tick_claiming"),
-                        ("knot", "001"),
+                        ("knot", "012"),
+                        ("knot", "047"),
+                        ("knot", "013"),
                         ("knot", "015"),
                         ("knot", "020"),
                         ("knot", "024"),
+                        ("knot", "026"),
+                        ("knot", "027"),
+                        ("knot", "045"),
+                        ("knot", "046"),
                         ("knot", "028"),
                         ("knot", "029"),
                         ("state", "unbonding")
@@ -2584,10 +2584,14 @@ fn test_tick_claiming_wo_idle() {
             Event::new("crates.io:drop-staking__drop-core-execute-tick_claiming").add_attributes(
                 vec![
                     ("action", "tick_claiming"),
-                    ("knot", "001"),
+                    ("knot", "012"),
+                    ("knot", "047"),
+                    ("knot", "013"),
                     ("knot", "015"),
                     ("knot", "020"),
                     ("knot", "024"),
+                    ("knot", "026"),
+                    ("knot", "027"),
                     ("knot", "000"),
                     ("state", "idle")
                 ]
@@ -2949,9 +2953,12 @@ fn test_tick_staking_to_unbonding() {
                 Event::new("crates.io:drop-staking__drop-core-execute-tick_staking")
                     .add_attributes(vec![
                         ("action", "tick_staking"),
-                        ("knot", "001"),
                         ("knot", "022"),
                         ("knot", "024"),
+                        ("knot", "026"),
+                        ("knot", "027"),
+                        ("knot", "045"),
+                        ("knot", "046"),
                         ("knot", "028"),
                         ("knot", "029"),
                         ("state", "unbonding"),
@@ -3089,9 +3096,10 @@ fn test_tick_staking_to_idle() {
             Event::new("crates.io:drop-staking__drop-core-execute-tick_staking").add_attributes(
                 vec![
                     ("action", "tick_staking"),
-                    ("knot", "001"),
                     ("knot", "022"),
                     ("knot", "024"),
+                    ("knot", "026"),
+                    ("knot", "027"),
                     ("knot", "000"),
                     ("state", "idle"),
                 ]

--- a/graph.gv
+++ b/graph.gv
@@ -1,5 +1,4 @@
 digraph G {
-    K001 [label = "K001\ncheck icq response freshness";shape = "diamond";];
     K000 [label = "K000\nidle";];
     K002 [label = "K002\ncache exchange rate";shape = "box";];
     K003 [label = "K003\ncheck last idle call\nidle_min_interval reached";shape = "diamond";];
@@ -19,7 +18,6 @@ digraph G {
     K005 [label = "K005\nUnbondingTimeIsClose?";shape = "diamond";];
     K007 [label = "K007\nHow many unbonding\nbatches ready to transfer?";shape = "hexagon";];
     K008 [label = "K008\n compose TransferReadyBatchesMsg";shape = "box";];
-    K045 [label = "K045\nNo batched ready";shape = "box";];
     K046 [label = "K046\n compose TransferReadyBatchesMsg\nmany batches";shape = "box";];
     
     K009 [label = "K009\nAre delegations fresh";shape = "diamond";];
@@ -43,7 +41,6 @@ digraph G {
     
     ERR [label = "exit";];
     
-    K001 -> K000;
     K000 -> K002;
     K002 -> K003;
     K003 -> K033 [taillabel = "no";];
@@ -58,15 +55,15 @@ digraph G {
     K042 -> K043;
     K041 -> ERR [taillabel = "no";];
     
-    K003 -> K005 [taillabel = "yes";];
+    K003 -> K004 [taillabel = "yes";];
+    K004 -> K005;
     K005 -> ERR [taillabel = "yes";];
     K005 -> K007 [taillabel = "no";];
     
-    K007 -> K045 [taillabel = "0";];
     K007 -> K008 [taillabel = "1";];
     K007 -> K046 [taillabel = ">1";];
-    
-    K045 -> K009;
+    K007 -> K009 [taillabel = "no";];
+
     K008 -> K009;
     K046 -> K009;
     
@@ -85,26 +82,10 @@ digraph G {
     K028 -> K029;
     
     K024 -> K000 [taillabel = "no";];
-    K010 -> K011 [taillabel = "no";];
+    K010 -> K011 [taillabel = "yes";];
     K011 -> K012;
-    K012 -> K004;
     
-    K000 -> K004;
-    K029 -> K004;
-    K022 -> K004;
-    K017 -> K004;
-    
-    K001 -> K038;
     K038 -> K000;
-    
-    K001 -> K043;
     K043 -> K000;
-    
-    K001 -> K035;
     K035 -> K000;
-    
-    K001 -> K015;
-    K001 -> K020;
-    K001 -> K022;
-    K001 -> K029;
 }

--- a/graph.gv
+++ b/graph.gv
@@ -1,46 +1,61 @@
 digraph G {
-    K000 [label = "K000\nidle";];
-    K002 [label = "K002\ncache exchange rate";shape = "box";];
-    K003 [label = "K003\ncheck last idle call\nidle_min_interval reached";shape = "diamond";];
-    
-    K033 [label = "K033\nis there some non-native rewards";shape = "diamond";];
-    K034 [label = "K034\ntransfer non-native rewards msg";shape = "box";];
-    K035 [label = "K035\nNonNativeRewardsTransfer";];
-    
-    K036 [label = "K036\nis there pending LSM shares\nto redeem";shape = "diamond";];
-    K037 [label = "K037\nredeem pending LSM shares msg";shape = "box";];
-    K038 [label = "K038\nLSMRedeem";];
-    
-    K041 [label = "K041\nis there pending LSM shares\nto transfer";shape = "diamond";];
-    K042 [label = "K042\ntransfer pending LSM shares msg";shape = "box";];
-    K043 [label = "K043\nLSMTransfer";];
-    
-    K005 [label = "K005\nUnbondingTimeIsClose?";shape = "diamond";];
-    K007 [label = "K007\nHow many unbonding\nbatches ready to transfer?";shape = "hexagon";];
-    K008 [label = "K008\n compose TransferReadyBatchesMsg";shape = "box";];
-    K046 [label = "K046\n compose TransferReadyBatchesMsg\nmany batches";shape = "box";];
-    
-    K009 [label = "K009\nAre delegations fresh";shape = "diamond";];
-    K010 [label = "K010\nAny validators to claim";shape = "diamond";];
-    
-    K015 [label = "K015\nAnything to stake";shape = "diamond";];
-    K016 [label = "K016\ncompose Stake msg";shape = "box";];
-    K017 [label = "K017\nStakingBond";];
-    
-    K020 [label = "K020\nRewards to stake";shape = "diamond";];
-    K021 [label = "K021\ncompose Stake rewards msg";shape = "box";];
-    K022 [label = "K022\nStakingRewards";];
-    
-    K024 [label = "K024\nAny batch to be unbonded?";shape = "diamond";];
-    K028 [label = "K028\ncompose unbond msg";shape = "box";];
-    K029 [label = "K029\nUnbonding";];
-    
-    K011 [label = "K011\ncompose Claim msg";shape = "box";];
-    K012 [label = "K012\nClaiming";];
-    K004 [label = "K004\nUpdate last idle call";];
-    
-    ERR [label = "exit";];
-    
+    layout=dot;
+    rankdir=TB;  // Top to Bottom direction
+
+    // Define individual ranks for the specific lines
+    {
+        rank=same;
+        K000 [label = "K000\nidle", shape=circle, fixedsize=true, width=1.5, height=1.5];
+    }
+
+    {
+        rank=same;
+        K002 [label = "K002\ncache exchange rate", shape=box, fixedsize=true, width=3, height=1];
+    }
+
+    {
+        rank=same;
+        K003 [label = "K003\ncheck last idle call\nidle_min_interval reached", shape=diamond];
+        K033 [label = "K033\nis there some non-native rewards", shape=diamond];
+        K036 [label = "K036\nis there pending LSM shares\nto redeem", shape=diamond];
+        K041 [label = "K041\nis there pending LSM shares\nto transfer", shape=polygon, sides=4, skew=.4];
+    }
+
+    {
+        rank=same;
+        K010 [label = "K010\nAny validators to claim", shape=diamond];
+        K015 [label = "K015\nAnything to stake", shape=diamond];
+        K020 [label = "K020\nRewards to stake", shape=diamond];
+        K024 [label = "K024\nIs there a failed batch?", shape=diamond];
+    }
+    {
+        rank=same;
+    K011 [label = "K011\ncompose Claim msg", shape=box];
+    K016 [label = "K016\ncompose Stake msg", shape=box];
+    K021 [label = "K021\ncompose Stake rewards msg", shape=box];
+    }
+    // The rest of the nodes
+    K004 [label = "K004\nUpdate last idle call"];
+    K005 [label = "K005\nIs Unbonding Time Far?", shape=polygon, sides=4, skew=.4];
+    K007 [label = "K007\nHow many unbonding\nbatches ready to transfer?", shape=hexagon];
+    K008 [label = "K008\ncompose TransferReadyBatchesMsg", shape=box];
+    K009 [label = "K009\nAre delegations fresh", shape=polygon, sides=4, skew=.4];
+    K012 [label = "K012\nClaiming"];
+    K013 [label = "K013\nWas there withdrawals?"];
+    K014 [label = "K014\nMark batches as withdrawn", shape=box];
+    K017 [label = "K017\nStakingBond"];
+    K022 [label = "K022\nStakingRewards"];
+    K025 [label = "K025\nTake failed batch as one to unbond", shape=box];
+    K026 [label = "K026\nTake the last batch as one to unbond", shape=box];
+    K028 [label = "K028\ncompose unbond msg", shape=box];
+    K029 [label = "K029\nUnbonding"];
+    K035 [label = "K035\nNonNativeRewardsTransfer"];
+    K037 [label = "K037\nredeem pending LSM shares msg", shape=box, fixedsize=true, width=3, height=1];
+    K038 [label = "K038\nLSMRedeem", shape=circle, fixedsize=true, width=1.5, height=1.5];
+    K042 [label = "K042\ntransfer pending LSM shares msg", shape=box, fixedsize=true, width=3, height=1];
+    K043 [label = "K043\nLSMTransfer"];
+    K047 [label = "K047\nIs answer type correct?", shape=polygon, sides=4, skew=.4];
+
     K000 -> K002;
     K002 -> K003;
     K003 -> K033 [taillabel = "no";];
@@ -51,41 +66,63 @@ digraph G {
     K036 -> K037 [taillabel = "yes";];
     K037 -> K038;
     K036 -> K041 [taillabel = "no";];
-    K041 -> K042 [taillabel = "yes";];
+    K041 -> K042;
     K042 -> K043;
-    K041 -> ERR [taillabel = "no";];
-    
+
     K003 -> K004 [taillabel = "yes";];
     K004 -> K005;
-    K005 -> ERR [taillabel = "yes";];
-    K005 -> K007 [taillabel = "no";];
-    
+    K005 -> K007;
+
     K007 -> K008 [taillabel = "1";];
-    K007 -> K046 [taillabel = ">1";];
+    K007 -> K048 [taillabel = ">1";];
     K007 -> K009 [taillabel = "no";];
 
     K008 -> K009;
-    K046 -> K009;
+    K048 -> K009;
     
-    K009 -> ERR [taillabel = "no";];
-    K009 -> K010 [taillabel = "yes";];
+    K009 -> K010;
     K010 -> K015 [taillabel = "no";];
+
     K015 -> K016 [taillabel = "yes";];
     K016 -> K017;
-    
+
     K015 -> K020 [taillabel = "no";];
     K020 -> K021 [taillabel = "yes";];
     K021 -> K022;
-    
+
     K020 -> K024 [taillabel = "no";];
-    K024 -> K028 [taillabel = "yes";];
+    K024 -> K025 [taillabel = "yes";];
     K028 -> K029;
-    
-    K024 -> K000 [taillabel = "no";];
+
+    K024 -> K026 [taillabel = "no";];
     K010 -> K011 [taillabel = "yes";];
     K011 -> K012;
-    
+
     K038 -> K000;
     K043 -> K000;
     K035 -> K000;
+
+    K013 -> K014 [taillabel = "yes";];
+    K013 -> K015 [taillabel = "no";];
+
+    K012 -> K047 [taillabel = "ACK";];
+    K012 -> K015 [taillabel = "ERR";];
+    K047 -> K013;
+    K014 -> K015;
+
+    K017 -> K020;
+    K022 -> K024;
+
+    K029 -> K030 [taillabel = "ACK";];
+    K029 -> K031 [taillabel = "ERR";];
+
+    K030 -> K000;
+    K031 -> K000;
+    K025 -> K027;
+    K026 -> K027;
+
+    K027 -> K045 [taillabel = "yes";];
+    K027 -> K000 [taillabel = "no";];
+    K045 -> K046;
+    K046 -> K028;
 }

--- a/graph.gv
+++ b/graph.gv
@@ -1,60 +1,230 @@
 digraph G {
     layout=dot;
-    rankdir=TB;  // Top to Bottom direction
-
-    // Define individual ranks for the specific lines
-    {
-        rank=same;
-        K000 [label = "K000\nidle", shape=circle, fixedsize=true, width=1.5, height=1.5];
-    }
+    rankdir=TB;
 
     {
         rank=same;
-        K002 [label = "K002\ncache exchange rate", shape=box, fixedsize=true, width=3, height=1];
+        K000 [
+            label = "K000\nidle",
+            shape=circle, fixedsize=true, width=1.5, height=1.5
+        ];
     }
 
     {
         rank=same;
-        K003 [label = "K003\ncheck last idle call\nidle_min_interval reached", shape=diamond];
-        K033 [label = "K033\nis there some non-native rewards", shape=diamond];
-        K036 [label = "K036\nis there pending LSM shares\nto redeem", shape=diamond];
-        K041 [label = "K041\nis there pending LSM shares\nto transfer", shape=polygon, sides=4, skew=.4];
+        K002 [
+            label = "K002\ncache exchange rate",
+            shape=box, fixedsize=true, width=3, height=1
+        ];
     }
 
     {
         rank=same;
-        K010 [label = "K010\nAny validators to claim", shape=diamond];
-        K015 [label = "K015\nAnything to stake", shape=diamond];
-        K020 [label = "K020\nRewards to stake", shape=diamond];
-        K024 [label = "K024\nIs there a failed batch?", shape=diamond];
+        K003 [
+            label = "K003\ncheck last idle call\nidle_min_interval reached",
+            shape=diamond, fixedsize=true, width=4, height=1.5
+        ];
+        K033 [
+            label = "K033\nis there some non-native rewards",
+            shape=diamond, fixedsize=true, width=4, height=1.5
+        ];
+        K036 [
+            label = "K036\nis there pending LSM shares\nto redeem",
+            shape=diamond, fixedsize=true, width=4, height=1.5
+        ];
+        K041 [
+            label = "K041\nis there pending LSM shares\nto transfer",
+            shape=polygon, sides=4, skew=.4, fixedsize=true, width=3, height=1
+        ];
     }
+
     {
         rank=same;
-    K011 [label = "K011\ncompose Claim msg", shape=box];
-    K016 [label = "K016\ncompose Stake msg", shape=box];
-    K021 [label = "K021\ncompose Stake rewards msg", shape=box];
+        K004 [
+            label = "K004\nUpdate last idle call",
+            shape=box, fixedsize=true, width=3, height=1
+        ];
+        K034 [
+            label = "K034\nSend non-native rewards to the\nmanager",
+            shape=house, fixedsize=true, width=3, height=1
+        ];
+        K037 [
+            label = "K037\nredeem pending LSM shares msg",
+            shape=house, fixedsize=true, width=3, height=1
+        ];
+        K042 [
+            label = "K042\ntransfer pending LSM shares msg",
+            shape=house, fixedsize=true, width=3, height=1
+        ];
     }
-    // The rest of the nodes
-    K004 [label = "K004\nUpdate last idle call"];
-    K005 [label = "K005\nIs Unbonding Time Far?", shape=polygon, sides=4, skew=.4];
-    K007 [label = "K007\nHow many unbonding\nbatches ready to transfer?", shape=hexagon];
-    K008 [label = "K008\ncompose TransferReadyBatchesMsg", shape=box];
-    K009 [label = "K009\nAre delegations fresh", shape=polygon, sides=4, skew=.4];
-    K012 [label = "K012\nClaiming"];
-    K013 [label = "K013\nWas there withdrawals?"];
-    K014 [label = "K014\nMark batches as withdrawn", shape=box];
-    K017 [label = "K017\nStakingBond"];
-    K022 [label = "K022\nStakingRewards"];
-    K025 [label = "K025\nTake failed batch as one to unbond", shape=box];
-    K026 [label = "K026\nTake the last batch as one to unbond", shape=box];
-    K028 [label = "K028\ncompose unbond msg", shape=box];
-    K029 [label = "K029\nUnbonding"];
-    K035 [label = "K035\nNonNativeRewardsTransfer"];
-    K037 [label = "K037\nredeem pending LSM shares msg", shape=box, fixedsize=true, width=3, height=1];
-    K038 [label = "K038\nLSMRedeem", shape=circle, fixedsize=true, width=1.5, height=1.5];
-    K042 [label = "K042\ntransfer pending LSM shares msg", shape=box, fixedsize=true, width=3, height=1];
-    K043 [label = "K043\nLSMTransfer"];
-    K047 [label = "K047\nIs answer type correct?", shape=polygon, sides=4, skew=.4];
+
+    {
+        rank=same;
+        K005 [
+            label = "K005\nIs Unbonding Time Far?",
+            shape=polygon, sides=4, skew=.4, fixedsize=true, width=3, height=1
+        ];
+        K035 [
+            label = "K035\nNonNative\nRewardsTransfer",
+            shape=circle, fixedsize=true, width=1.5, height=1.5
+        ];
+        K038 [
+            label = "K038\nLSMRedeem",
+            shape=circle, fixedsize=true, width=1.5, height=1.5
+        ];
+        K043 [
+            label = "K043\nLSMTransfer",
+            shape=circle, fixedsize=true, width=1.5, height=1.5
+        ];
+    }
+
+    {
+        rank=same;
+        K007 [
+            label = "K007\nHow many unbonding\nbatches ready to transfer?",
+            shape=hexagon, fixedsize=true, width=3, height=1
+        ];
+    }
+
+    {
+        rank=same;
+        K008 [
+            label = "K008\nCompose TransferReadyBatchesMsg",
+            shape=box, fixedsize=true, width=3, height=1
+        ];
+        K048 [
+            label = "K048\nCompose multiple batch transfer",
+            shape=box, fixedsize=true, width=3, height=1
+        ];
+    }
+
+    {
+        rank=same;
+        K009 [
+            label = "K009\nAre delegations fresh",
+            shape=polygon, sides=4, skew=.4, fixedsize=true, width=3, height=1
+        ];
+    }
+
+    {
+        rank=same;
+        K010 [
+            label = "K010\nAny validators to claim",
+            shape=diamond, fixedsize=true, width=4, height=1.5
+        ];
+        K015 [
+            label = "K015\nAnything to stake",
+            shape=diamond, fixedsize=true, width=4, height=1.5
+        ];
+        K020 [
+            label = "K020\nRewards to stake",
+            shape=diamond, fixedsize=true, width=4, height=1.5
+        ];
+        K024 [
+            label = "K024\nIs there a failed batch?",
+            shape=diamond, fixedsize=true, width=4, height=1.5
+        ];
+    }
+
+    {
+        rank=same;
+        K011 [
+            label = "K011\ncompose Claim msg",
+            shape=house, fixedsize=true, width=3, height=1
+        ];
+        K016 [
+            label = "K016\ncompose Stake msg",
+            shape=house, fixedsize=true, width=3, height=1
+        ];
+        K021 [
+            label = "K021\ncompose Stake rewards msg",
+            shape=house, fixedsize=true, width=3, height=1
+        ];
+        K025 [
+            label = "K025\nTake failed batch as one to unbond",
+            shape=box, fixedsize=true, width=3, height=1
+        ];
+        K026 [
+            label = "K026\nTake the last batch as one to unbond",
+            shape=box, fixedsize=true, width=3, height=1
+        ];
+    }
+
+    {
+        rank=same;
+        K012 [
+            label = "K012\nClaiming",
+            shape=circle, fixedsize=true, width=1.5, height=1.5
+        ];
+        K017 [
+            label = "K017\nStakingBond",
+            shape=circle, fixedsize=true, width=1.5, height=1.5
+        ];
+        K022 [
+            label = "K022\nStakingRewards",
+            shape=circle, fixedsize=true, width=1.5, height=1.5
+        ];
+        K027 [
+            label = "K027\nUnbonding conditions are met",
+            shape=diamond, fixedsize=true, width=4, height=1.5
+        ];
+    }
+
+    {
+        rank=same;
+        K047 [
+            label = "K047\nIs answer type correct?",
+            shape=polygon, sides=4, skew=.4, fixedsize=true, width=3, height=1
+        ];
+        K045 [
+            label = "K045\nMark the batch as\nUnbonding Requested",
+            shape=box, fixedsize=true, width=3, height=1
+        ];
+    }
+
+    {
+        rank=same;
+        K013 [
+            label = "K013\nWas there withdrawals?",
+            shape=diamond, fixedsize=true, width=4, height=1.5
+        ];
+        K046 [
+            label = "K046\nCreate new unbonding batch",
+            shape=box, fixedsize=true, width=3, height=1
+        ];
+    }
+
+    {
+        rank=same;
+        K014 [
+            label = "K014\nMark batches as withdrawn",
+            shape=box, fixedsize=true, width=3, height=1
+        ];
+        K028 [
+            label = "K028\ncompose unbond msg",
+            shape=house, fixedsize=true, width=3, height=1
+        ];
+    }
+
+    {
+        rank=same;
+        K029 [
+            label = "K029\nUnbonding",
+            shape=circle, fixedsize=true, width=1.5, height=1.5
+        ];
+    }
+
+    {
+        rank=same;
+        K030 [
+            label = "K030\nMark batch as Unbonded",
+            shape=box, fixedsize=true, width=3, height=1
+        ];
+        K031 [
+            label = "K031\nMark batch as UnbondingFailed",
+            shape=box, fixedsize=true, width=3, height=1
+        ];
+    }
 
     K000 -> K002;
     K002 -> K003;


### PR DESCRIPTION
1. More knots are added to cover most of the state machine actions
2. The error node is removed. Instead, conditions that fail transactions are changed into a parallelogram-type condition which fails transactions if a condition isn't met. As a bonus now we understand better if the state is changed in cases when we return to the previous state, it became more explicit
3. Check ICQ freshness is removed. We can rely on the fact it's done every time we leave a state and adding that as a separate state will make both scheme and implementation much more complex
4. Graph is prettified:
![image](https://github.com/hadronlabs-org/drop-contracts/assets/83083413/ceeff109-8408-463c-8118-8b8260730032)
