### PR TITLE
Fix: DRP-230. LSM shares redeem

### DIFF
--- a/contracts/core/src/contract.rs
+++ b/contracts/core/src/contract.rs
@@ -84,7 +84,7 @@ pub fn instantiate(
     TOTAL_LSM_SHARES.save(deps.storage, &0)?;
     BONDED_AMOUNT.save(deps.storage, &Uint128::zero())?;
     NON_NATIVE_REWARDS_CONFIG.save(deps.storage, &vec![])?;
-    LAST_LSM_REDEEM.save(deps.storage, &0)?;
+    LAST_LSM_REDEEM.save(deps.storage, &env.block.time.seconds())?;
     Ok(response("instantiate", CONTRACT_NAME, attrs))
 }
 

--- a/contracts/core/src/contract.rs
+++ b/contracts/core/src/contract.rs
@@ -1577,13 +1577,6 @@ pub fn get_pending_redeem_msg<T>(
         .count();
     let last_lsm_redeem = LAST_LSM_REDEEM.load(deps.storage)?;
     let lsm_redeem_threshold = config.lsm_redeem_threshold as usize;
-    println!(
-        "Pending LSM shares count: {}, last LSM redeem: {}, threshold: {}, block time: {}",
-        pending_lsm_shares_count,
-        last_lsm_redeem,
-        lsm_redeem_threshold,
-        env.block.time.seconds()
-    );
 
     if pending_lsm_shares_count == 0
         || ((pending_lsm_shares_count < lsm_redeem_threshold)

--- a/contracts/core/src/contract.rs
+++ b/contracts/core/src/contract.rs
@@ -1566,7 +1566,7 @@ pub fn get_non_native_rewards_and_fee_transfer_msg<T>(
     })))
 }
 
-fn get_pending_redeem_msg<T>(
+pub fn get_pending_redeem_msg<T>(
     deps: Deps<NeutronQuery>,
     config: &Config,
     env: &Env,
@@ -1577,6 +1577,14 @@ fn get_pending_redeem_msg<T>(
         .count();
     let last_lsm_redeem = LAST_LSM_REDEEM.load(deps.storage)?;
     let lsm_redeem_threshold = config.lsm_redeem_threshold as usize;
+    println!(
+        "Pending LSM shares count: {}, last LSM redeem: {}, threshold: {}, block time: {}",
+        pending_lsm_shares_count,
+        last_lsm_redeem,
+        lsm_redeem_threshold,
+        env.block.time.seconds()
+    );
+
     if pending_lsm_shares_count == 0
         || ((pending_lsm_shares_count < lsm_redeem_threshold)
             && (last_lsm_redeem + config.lsm_redeem_maximum_interval > env.block.time.seconds()))

--- a/contracts/core/src/contract.rs
+++ b/contracts/core/src/contract.rs
@@ -1579,13 +1579,15 @@ fn get_pending_redeem_msg<T>(
     let lsm_redeem_threshold = config.lsm_redeem_threshold as usize;
     if pending_lsm_shares_count == 0
         || ((pending_lsm_shares_count < lsm_redeem_threshold)
-            || (last_lsm_redeem + config.lsm_redeem_maximum_interval > env.block.time.seconds()))
+            && (last_lsm_redeem + config.lsm_redeem_maximum_interval > env.block.time.seconds()))
     {
         return Ok(None);
     }
     let shares_to_redeeem = LSM_SHARES_TO_REDEEM
         .range(deps.storage, None, None, cosmwasm_std::Order::Ascending)
+        .take(lsm_redeem_threshold)
         .collect::<StdResult<Vec<_>>>()?;
+
     let items = shares_to_redeeem
         .iter()
         .map(|(local_denom, (denom, amount))| RedeemShareItem {

--- a/contracts/core/src/tests.rs
+++ b/contracts/core/src/tests.rs
@@ -1086,7 +1086,7 @@ fn test_idle_tick_pending_lsm_redeem() {
         )
         .unwrap();
     let mut env = mock_env();
-    env.block.time = Timestamp::from_seconds(100);
+    env.block.time = Timestamp::from_seconds(99);
     let res = execute(
         deps.as_mut(),
         env.clone(),
@@ -1094,6 +1094,7 @@ fn test_idle_tick_pending_lsm_redeem() {
         ExecuteMsg::Tick {},
     );
     assert!(res.is_err());
+
     LSM_SHARES_TO_REDEEM
         .save(
             deps.as_mut().storage,

--- a/contracts/factory/src/msg.rs
+++ b/contracts/factory/src/msg.rs
@@ -31,7 +31,7 @@ pub struct CoreParams {
     pub unbonding_safe_period: u64,
     pub unbond_batch_switch_time: u64,
     pub lsm_min_bond_amount: Uint128,
-    pub lsm_redeem_threshold: u64,
+    pub lsm_redeem_threshold: u64,    //amount of lsm denoms
     pub lsm_redeem_max_interval: u64, //seconds
     pub bond_limit: Option<Uint128>,
     pub min_stake_amount: Uint128,

--- a/packages/base/src/msg/core.rs
+++ b/packages/base/src/msg/core.rs
@@ -23,7 +23,7 @@ pub struct InstantiateMsg {
     pub base_denom: String,
     pub remote_denom: String,
     pub lsm_min_bond_amount: Uint128,
-    pub lsm_redeem_threshold: u64,
+    pub lsm_redeem_threshold: u64,     //amount of lsm denoms
     pub lsm_redeem_max_interval: u64,  //seconds
     pub idle_min_interval: u64,        //seconds
     pub unbonding_period: u64,         //seconds

--- a/packages/base/src/state/core.rs
+++ b/packages/base/src/state/core.rs
@@ -23,7 +23,7 @@ pub struct ConfigOptional {
     pub pump_ica_address: Option<String>,
     pub transfer_channel_id: Option<String>,
     pub lsm_min_bond_amount: Option<Uint128>,
-    pub lsm_redeem_threshold: Option<u64>,
+    pub lsm_redeem_threshold: Option<u64>, //amount of lsm denoms
     pub lsm_redeem_maximum_interval: Option<u64>,
     pub bond_limit: Option<Uint128>,
     pub fee: Option<Decimal>,
@@ -50,7 +50,7 @@ pub struct Config {
     pub pump_ica_address: Option<String>,
     pub transfer_channel_id: String,
     pub lsm_min_bond_amount: Uint128,
-    pub lsm_redeem_threshold: u64,
+    pub lsm_redeem_threshold: u64,        //amount of lsm denoms
     pub lsm_redeem_maximum_interval: u64, //seconds
     pub bond_limit: Option<Uint128>,
     pub fee: Option<Decimal>,


### PR DESCRIPTION
There are two problems:

* Timeout works in the wrong way: currently, it prevents redemption to happen when it should force it instead;
* Redemption happens for all shares instead of the threshold (might cause gaslimit error).