### PR TITLE
chore: remove unused field from core contract

### DIFF
--- a/contracts/core/src/tests.rs
+++ b/contracts/core/src/tests.rs
@@ -44,7 +44,6 @@ fn get_default_config(
         unbonding_safe_period,
         unbond_batch_switch_time,
         pump_ica_address: Some("pump_address".to_string()),
-        transfer_channel_id: "transfer_channel".to_string(),
         emergency_address: None,
         icq_update_delay: 5,
     }
@@ -102,7 +101,6 @@ fn test_update_config() {
             unbonding_safe_period: 120,
             unbond_batch_switch_time: 2000,
             pump_ica_address: Some("old_pump_address".to_string()),
-            transfer_channel_id: "old_transfer_channel".to_string(),
             emergency_address: Some("old_emergency_address".to_string()),
             owner: "admin".to_string(),
             icq_update_delay: 5,
@@ -123,7 +121,6 @@ fn test_update_config() {
         unbonding_safe_period: Some(20),
         unbond_batch_switch_time: Some(12000),
         pump_ica_address: Some("new_pump_address".to_string()),
-        transfer_channel_id: Some("new_transfer_channel".to_string()),
         rewards_receiver: Some("new_rewards_receiver".to_string()),
         emergency_address: Some("new_emergency_address".to_string()),
     };
@@ -136,7 +133,6 @@ fn test_update_config() {
         unbonding_safe_period: 20,
         unbond_batch_switch_time: 12000,
         pump_ica_address: Some("new_pump_address".to_string()),
-        transfer_channel_id: "new_transfer_channel".to_string(),
         emergency_address: Some("new_emergency_address".to_string()),
         icq_update_delay: 5,
     };

--- a/contracts/factory/src/contract.rs
+++ b/contracts/factory/src/contract.rs
@@ -341,7 +341,6 @@ pub fn instantiate(
                 unbonding_safe_period: msg.core_params.unbonding_safe_period,
                 unbond_batch_switch_time: msg.core_params.unbond_batch_switch_time,
                 idle_min_interval: msg.core_params.idle_min_interval,
-                transfer_channel_id: msg.remote_opts.transfer_channel_id.to_string(),
                 owner: env.contract.address.to_string(),
                 emergency_address: None,
                 icq_update_delay: msg.core_params.icq_update_delay,

--- a/contracts/factory/src/tests.rs
+++ b/contracts/factory/src/tests.rs
@@ -341,7 +341,6 @@ fn test_instantiate() {
                         label: "drop-staking-core".to_string(),
                         msg: to_json_binary(&CoreInstantiateMsg {
                             factory_contract: "factory_contract".to_string(),
-
                             base_denom: "base_denom".to_string(),
                             remote_denom: "denom".to_string(),
                             idle_min_interval: 0,
@@ -349,7 +348,6 @@ fn test_instantiate() {
                             unbonding_safe_period: 0,
                             unbond_batch_switch_time: 0,
                             pump_ica_address: None,
-                            transfer_channel_id: "channel-0".to_string(),
                             owner: "factory_contract".to_string(),
                             emergency_address: None,
                             icq_update_delay: 0
@@ -612,7 +610,6 @@ fn test_update_config_core_unauthorized() {
         unbonding_safe_period: None,
         unbond_batch_switch_time: None,
         pump_ica_address: None,
-        transfer_channel_id: None,
         rewards_receiver: None,
         emergency_address: None,
     };
@@ -648,7 +645,6 @@ fn test_update_config_core() {
         unbonding_safe_period: Some(1u64),
         unbond_batch_switch_time: Some(1u64),
         pump_ica_address: Some("pump_ica_address1".to_string()),
-        transfer_channel_id: Some("channel-1".to_string()),
         rewards_receiver: Some("rewards_receiver1".to_string()),
         emergency_address: Some("emergency_address1".to_string()),
     };

--- a/packages/base/src/msg/core.rs
+++ b/packages/base/src/msg/core.rs
@@ -19,7 +19,6 @@ pub struct InstantiateMsg {
     pub unbonding_safe_period: u64,    //seconds
     pub unbond_batch_switch_time: u64, //seconds
     pub pump_ica_address: Option<String>,
-    pub transfer_channel_id: String,
     pub owner: String,
     pub emergency_address: Option<String>,
     pub icq_update_delay: u64, // blocks
@@ -35,7 +34,6 @@ impl InstantiateMsg {
             unbonding_safe_period: self.unbonding_safe_period,
             unbonding_period: self.unbonding_period,
             pump_ica_address: self.pump_ica_address,
-            transfer_channel_id: self.transfer_channel_id,
             unbond_batch_switch_time: self.unbond_batch_switch_time,
             emergency_address: self.emergency_address,
             icq_update_delay: self.icq_update_delay,

--- a/packages/base/src/state/core.rs
+++ b/packages/base/src/state/core.rs
@@ -16,7 +16,6 @@ pub struct ConfigOptional {
     pub unbonding_safe_period: Option<u64>,
     pub unbond_batch_switch_time: Option<u64>,
     pub pump_ica_address: Option<String>,
-    pub transfer_channel_id: Option<String>,
     pub rewards_receiver: Option<String>,
     pub emergency_address: Option<String>,
 }
@@ -31,7 +30,6 @@ pub struct Config {
     pub unbonding_safe_period: u64,    //seconds
     pub unbond_batch_switch_time: u64, //seconds
     pub pump_ica_address: Option<String>,
-    pub transfer_channel_id: String,
     pub emergency_address: Option<String>,
     pub icq_update_delay: u64, // blocks
 }

--- a/packages/base/src/state/core.rs
+++ b/packages/base/src/state/core.rs
@@ -34,7 +34,7 @@ pub struct Config {
     pub icq_update_delay: u64, // blocks
 }
 
-pub const CONFIG: Item<Config> = Item::new("config");
+pub const CONFIG: Item<Config> = Item::new("config_v2");
 
 #[cw_serde]
 #[derive(Copy)]

--- a/ts-client/lib/contractLib/dropCore.d.ts
+++ b/ts-client/lib/contractLib/dropCore.d.ts
@@ -213,7 +213,6 @@ export interface Config {
     idle_min_interval: number;
     pump_ica_address?: string | null;
     remote_denom: string;
-    transfer_channel_id: string;
     unbond_batch_switch_time: number;
     unbonding_period: number;
     unbonding_safe_period: number;
@@ -318,7 +317,6 @@ export interface ConfigOptional {
     pump_ica_address?: string | null;
     remote_denom?: string | null;
     rewards_receiver?: string | null;
-    transfer_channel_id?: string | null;
     unbond_batch_switch_time?: number | null;
     unbonding_period?: number | null;
     unbonding_safe_period?: number | null;
@@ -351,7 +349,6 @@ export interface InstantiateMsg {
     owner: string;
     pump_ica_address?: string | null;
     remote_denom: string;
-    transfer_channel_id: string;
     unbond_batch_switch_time: number;
     unbonding_period: number;
     unbonding_safe_period: number;

--- a/ts-client/lib/contractLib/dropFactory.d.ts
+++ b/ts-client/lib/contractLib/dropFactory.d.ts
@@ -697,7 +697,6 @@ export interface ConfigOptional {
     pump_ica_address?: string | null;
     remote_denom?: string | null;
     rewards_receiver?: string | null;
-    transfer_channel_id?: string | null;
     unbond_batch_switch_time?: number | null;
     unbonding_period?: number | null;
     unbonding_safe_period?: number | null;

--- a/ts-client/src/contractLib/dropCore.ts
+++ b/ts-client/src/contractLib/dropCore.ts
@@ -266,7 +266,6 @@ export interface Config {
   idle_min_interval: number;
   pump_ica_address?: string | null;
   remote_denom: string;
-  transfer_channel_id: string;
   unbond_batch_switch_time: number;
   unbonding_period: number;
   unbonding_safe_period: number;
@@ -371,7 +370,6 @@ export interface ConfigOptional {
   pump_ica_address?: string | null;
   remote_denom?: string | null;
   rewards_receiver?: string | null;
-  transfer_channel_id?: string | null;
   unbond_batch_switch_time?: number | null;
   unbonding_period?: number | null;
   unbonding_safe_period?: number | null;
@@ -404,7 +402,6 @@ export interface InstantiateMsg {
   owner: string;
   pump_ica_address?: string | null;
   remote_denom: string;
-  transfer_channel_id: string;
   unbond_batch_switch_time: number;
   unbonding_period: number;
   unbonding_safe_period: number;

--- a/ts-client/src/contractLib/dropFactory.ts
+++ b/ts-client/src/contractLib/dropFactory.ts
@@ -765,7 +765,6 @@ export interface ConfigOptional {
   pump_ica_address?: string | null;
   remote_denom?: string | null;
   rewards_receiver?: string | null;
-  transfer_channel_id?: string | null;
   unbond_batch_switch_time?: number | null;
   unbonding_period?: number | null;
   unbonding_safe_period?: number | null;


### PR DESCRIPTION
Since we deleted the unused `check_denom` module, turns out we can also delete the `transfer_channel_id` field. This change does not break existing deploy scripts and the migration handler turned out to be very simple.